### PR TITLE
Add route planning and pricing filter

### DIFF
--- a/leaflet
+++ b/leaflet
@@ -18,3 +18,8 @@
 <script src="https://cdn.jsdelivr.net/gh/tomickigrzegorz/autocomplete@1.8.3/dist/js/autocomplete.min.js"></script>
 <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
 <script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js'></script>
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/leaflet-routing-machine@latest/dist/leaflet-routing-machine.css"
+/>
+<script src="https://unpkg.com/leaflet-routing-machine@latest/dist/leaflet-routing-machine.js"></script>

--- a/main html map
+++ b/main html map
@@ -364,8 +364,18 @@
         <option value="Coal">Coal</option>
         <option value="Manganese">Manganese</option>
         <option value="Maputo_Corridor">Maputo Corridor</option>
-        <option value="Cross_Border">Cross Border</option>
+      <option value="Cross_Border">Cross Border</option>
       </select></form>
+  </div>
+  <div class="map-subtitle">Filter by Pricing</div>
+  <div class="route-filter w-form">
+    <select id="priceFilter" class="routes w-select">
+        <option value="all">All</option>
+        <option value="Refuel2Save+">Refuel2Save+</option>
+        <option value="Refuel2Save">Refuel2Save</option>
+        <option value="Classic">Classic</option>
+        <option value="Cross Border">Cross Border</option>
+    </select>
   </div>
   <div class="map-subtitle hidden">Legend</div>
   <div class="index-item"><img src="https://tfn.co.za/wp-content/uploads/2024/09/r2sPlus.svg" loading="lazy" alt="" class="pin-icon-ex">
@@ -389,6 +399,10 @@
     <div class="search-outer w-embed">
       <div class="auto-search-wrapper">
         <input type="text" autocomplete="on" id="search" class="full-width" placeholder="Enter the city name">
+        <input type="text" id="depotSearch" class="full-width" placeholder="Search depot">
+        <input type="text" autocomplete="on" id="routeStart" class="full-width" placeholder="Route start">
+        <input type="text" autocomplete="on" id="routeEnd" class="full-width" placeholder="Route end">
+        <button type="button" id="planRoute" class="routes">Plan Route</button>
       </div>
     </div>
     <div id="map" class="map"></div>

--- a/map javascript
+++ b/map javascript
@@ -37,14 +37,14 @@ fetch('https://6f6twe9e95.execute-api.eu-north-1.amazonaws.com/default/getTfnDat
     
     var r2s = L.icon({
         iconUrl: 'https://tfn.co.za/wp-content/uploads/2024/09/r2s.svg',
-        iconSize: [34, 44.5],
-        iconAnchor: [17, 44.5],
+        iconSize: [40, 50],
+        iconAnchor: [20, 50],
         popupAnchor: [0, -45]
     });
     var r2sPlus = L.icon({
         iconUrl: 'https://tfn.co.za/wp-content/uploads/2024/09/r2sPlus.svg',
-        iconSize: [34, 44.5],
-        iconAnchor: [17, 44.5],
+        iconSize: [40, 50],
+        iconAnchor: [20, 50],
         popupAnchor: [0, -45]
     });
     var ss = L.icon({
@@ -116,46 +116,140 @@ fetch('https://6f6twe9e95.execute-api.eu-north-1.amazonaws.com/default/getTfnDat
     console.log(map);
     
     var dropdown = document.getElementById('routeFilter');
-    dropdown.addEventListener('change', function() {
-      var selectedRoute = this.value;
+    var priceDropdown = document.getElementById('priceFilter');
+    var depotSearch = document.getElementById('depotSearch');
+
+    function applyFilters() {
+      var selectedRoute = dropdown.value;
+      var selectedPrice = priceDropdown.value;
+      var searchTerm = depotSearch.value.toLowerCase();
       var loCount = 0;
-    
-      // Check if the selected option is "all"
-      if (selectedRoute === 'all') {
-        // Show all markers with staggered animation
-        markers.forEach(function(marker, index) {
-          marker.remove();
+
+      markers.forEach(function(marker) {
+        var depotData = marker.depotData;
+        var show = true;
+
+        if (selectedRoute !== 'all') {
+          if (selectedRoute === 'Cross_Border') {
+            show = show && !depotData.IsInSouthAfrica;
+          } else {
+            show = show && depotData[selectedRoute] === "True";
+          }
+        }
+
+        if (selectedPrice !== 'all') {
+          if (selectedPrice === 'Refuel2Save+') {
+            show = show && depotData.hasRefuel2SavePlusPromotions;
+          } else if (selectedPrice === 'Refuel2Save') {
+            show = show && depotData.isRefuel2SaveDepot && !depotData.hasRefuel2SavePlusPromotions && depotData.IsInSouthAfrica;
+          } else if (selectedPrice === 'Classic') {
+            show = show && !depotData.isRefuel2SaveDepot && depotData.IsInSouthAfrica;
+          } else if (selectedPrice === 'Cross Border') {
+            show = show && !depotData.IsInSouthAfrica;
+          }
+        }
+
+        if (searchTerm) {
+          show = show && depotData.Title.toLowerCase().includes(searchTerm);
+        }
+
+        if (show) {
           marker.addTo(map);
+          marker.visible = true;
           loCount++;
-        });
-      } else if (selectedRoute === 'Cross_Border') {
-        markers.forEach(function(marker, index) {
-          var depotData = marker.depotData;
-          var routeValue = !depotData.IsInSouthAfrica;
-          if (routeValue === true) {
-            marker.addTo(map);
-            loCount++;
-          } else {
-            // Hide marker
-            marker.remove();
-          }
-        });
-      } else {
-        // Loop through the markers and show/hide based on the selected route
-        markers.forEach(function(marker, index) {
-          var depotData = marker.depotData;
-          var routeValue = depotData[selectedRoute];
-          if (routeValue === "True") {
-            marker.addTo(map);
-            loCount++;
-          } else {
-            // Hide marker
-            marker.remove();
-          }
-        });
-      }
+        } else {
+          marker.remove();
+          marker.visible = false;
+        }
+      });
+
       filterCount.innerText = loCount;
-      console.log(markers);
+    }
+
+    dropdown.addEventListener('change', applyFilters);
+    priceDropdown.addEventListener('change', applyFilters);
+    depotSearch.addEventListener('input', applyFilters);
+    applyFilters();
+
+    let startCoords = null;
+    let endCoords = null;
+
+    new Autocomplete("routeStart", {
+      selectFirst: true,
+      howManyCharacters: 2,
+      onSearch: ({ currentValue }) => {
+        const api = `https://nominatim.openstreetmap.org/search?format=geojson&limit=5&city=${encodeURI(
+          currentValue
+        )}`;
+
+        return fetch(api)
+          .then((response) => response.json())
+          .then((data) => data.features)
+          .catch((error) => {
+            console.error(error);
+            return [];
+          });
+      },
+      onSubmit: ({ object }) => {
+        const [lng, lat] = object.geometry.coordinates;
+        startCoords = [lat, lng];
+      },
+    });
+
+    new Autocomplete("routeEnd", {
+      selectFirst: true,
+      howManyCharacters: 2,
+      onSearch: ({ currentValue }) => {
+        const api = `https://nominatim.openstreetmap.org/search?format=geojson&limit=5&city=${encodeURI(
+          currentValue
+        )}`;
+
+        return fetch(api)
+          .then((response) => response.json())
+          .then((data) => data.features)
+          .catch((error) => {
+            console.error(error);
+            return [];
+          });
+      },
+      onSubmit: ({ object }) => {
+        const [lng, lat] = object.geometry.coordinates;
+        endCoords = [lat, lng];
+      },
+    });
+
+    let routingControl;
+    document.getElementById("planRoute").addEventListener("click", function() {
+      if (!startCoords || !endCoords) {
+        alert("Please select both start and end locations");
+        return;
+      }
+      if (routingControl) {
+        map.removeControl(routingControl);
+      }
+      routingControl = L.Routing.control({
+        waypoints: [L.latLng(startCoords[0], startCoords[1]), L.latLng(endCoords[0], endCoords[1])],
+        addWaypoints: false,
+        draggableWaypoints: false,
+        routeWhileDragging: false,
+        show: false,
+      }).addTo(map);
+
+      routingControl.on('routesfound', function(e) {
+        const coords = e.routes[0].coordinates.map(c => L.latLng(c.lat, c.lng));
+        let count = 0;
+        markers.forEach(function(marker) {
+          if (!marker.visible) { marker.remove(); return; }
+          const near = coords.some(pt => marker.getLatLng().distanceTo(pt) <= 10000);
+          if (near) {
+            marker.addTo(map);
+            count++;
+          } else {
+            marker.remove();
+          }
+        });
+        filterCount.innerText = count;
+      });
     });
     
     // minimal configure


### PR DESCRIPTION
## Summary
- add leaflet routing machine dependency
- support filtering by pricing type
- allow searching by depot name
- include UI for planning a route between two places
- increase Refuel2Save pin sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6889d8653ff88330973ca72b53a24a10